### PR TITLE
Sign JWT with private key from .env file

### DIFF
--- a/src/components/Jitvideo.jsx
+++ b/src/components/Jitvideo.jsx
@@ -1,10 +1,40 @@
-import React, {useEffect} from 'react';
+import React, { useEffect } from 'react';
 import { JaaSMeeting } from "@jitsi/react-sdk";
+import { signJWT } from '../utils/jwt';
 
 const JitsiIframe = () => {
     const domain = import.meta.env.VITE_JITSI_DOMAIN;
     const appId = import.meta.env.VITE_JITSI_APP_ID;
-    const jwt = import.meta.env.VITE_JITSI_JWT;
+    const jwt = signJWT({
+        "kid": "vpaas-magic-cookie-6381f715d48d4625a56d59db90356bdb/f46f9f",
+        "typ": "JWT",
+        "alg": "RS256",
+        "aud": "jitsi",
+        "iss": "chat",
+        "iat": 1741580170,
+        "exp": 1842587490,
+        "nbf": 1741580165,
+        "sub": "vpaas-magic-cookie-6381f715d48d4625a56d59db90356bdb",
+        "context": {
+            "features": {
+                "livestreaming": true,
+                "outbound-call": true,
+                "sip-outbound-call": false,
+                "transcription": true,
+                "recording": true
+            },
+            "user": {
+                "hidden-from-recorder": false,
+                "moderator": true,
+                "name": "ramcharanslm8",
+                "id": "auth0|67ce19fd1541061096d64525",
+                "avatar": "",
+                "email": "ramcharanslm8@gmail.com"
+            }
+        },
+        "room": "*"
+    });
+
     return (
         <JaaSMeeting
             appId={appId}
@@ -13,8 +43,6 @@ const JitsiIframe = () => {
             configOverwrite={{
                 startWithAudioMuted: true, // Start muted (optional)
                 startWithVideoMuted: false, // Enable video by default
-
-
             }}
             interfaceConfigOverwrite={{
                 VIDEO_LAYOUT_FIT: "nocrop",
@@ -27,9 +55,7 @@ const JitsiIframe = () => {
             getIFrameRef={(iframeRef) => {
                 iframeRef.style.height = "100vh";
             }}
-
-            useStaging = { true }
-
+            useStaging={true}
         />
     );
 };

--- a/src/utils/jwt.js
+++ b/src/utils/jwt.js
@@ -1,0 +1,14 @@
+const jwt = require('jsonwebtoken');
+const fs = require('fs');
+
+function signJWT(payload) {
+  const privateKey = process.env.PRIVATE_KEY;
+  if (!privateKey) {
+    throw new Error('Private key not found in environment variables');
+  }
+
+  const token = jwt.sign(payload, privateKey, { algorithm: 'RS256' });
+  return token;
+}
+
+module.exports = { signJWT };


### PR DESCRIPTION
Add JWT signing with private key from `.env` file and pass to Jitsi.

* Add `src/utils/jwt.js` to handle JWT signing with private key from `.env` file.
* Import `signJWT` function in `src/components/Jitvideo.jsx`.
* Replace hardcoded JWT with signed JWT using `signJWT` function.
* Pass signed JWT to `JaaSMeeting` component.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/techieRahul17/InterVueX/pull/5?shareId=1a50a92e-013e-4791-ac70-6276217f7304).